### PR TITLE
effectively delete aliases on private repositories

### DIFF
--- a/dxf/main.py
+++ b/dxf/main.py
@@ -151,8 +151,11 @@ def doit(args, environ):
 
         elif args.op == "del-alias":
             for name in args.args:
-                for dgst in dxf_obj.del_alias(name):
-                    print(dgst)
+                try:
+                    print('\n'.join(dxf_obj.del_alias(name)))
+                # pylint: disable=broad-except
+                except Exception as error:
+                    sys.stderr.write('error: %r: %s\n' %(name, error))
 
         elif args.op == 'list-aliases':
             if len(args.args) > 0:


### PR DESCRIPTION
Hi,

I propose this change to make aliases deletion effective on private registry, tested against registry github.com/docker/distribution v2.4.0.

I would like a switch on the command line to delete the alias and the blobs, ie. `dxf del-alias --blob XXX YYY`
What would you think about it?