### PR TITLE
Read auth from file when user/password are not provided

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import json
 import sys
+import dockercloud.api.auth
 
 try:
     import urllib.parse as urlparse
@@ -206,7 +207,9 @@ class DXFBase(object):
                 'Authorization': 'Basic ' + base64.b64encode(_to_bytes_2and3(username + ':' + password)).decode('utf-8')
             }
         else:
-            headers = {}
+            headers = {
+                'Authorization': 'Basic ' + dockercloud.api.auth.load_from_file("~/.docker/config.json")
+            }
         if 'bearer' in parsed:
             info = parsed['bearer']
             if actions and self._repo:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pylint>=1.6.4
 pytest>=3.0.5
 pytest-cov>=2.4.0
 coveralls>=1.1
+python-dockercloud

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pylint>=1.6.4
 pytest>=3.0.5
 pytest-cov>=2.4.0
 coveralls>=1.1
-python-dockercloud
+python-dockercloud>=1.0.12

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
                       'www-authenticate>=0.9.2',
                       'requests>=2.9.0',
                       'jws>=0.1.3',
-                      'tqdm>=4.10.0']
+                      'tqdm>=4.10.0',
+                      'python-dockercloud>=1.0.12']
 )


### PR DESCRIPTION
Use dockercloud.api.auth to read credentials from ~/.docker/config.json