### PR TITLE
Add option to disable TLS certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The `dxf` command-line tool uses the following environment variables:
 - `DXF_PROGRESS` - If this is set to `1`, a progress bar is displayed (on standard error) during `push-blob` and `pull-blob`. If this is set to `0`, a progress bar is not displayed. If this is set to any other value, a progress bar is only displayed if standard error is a terminal.
 - `DXF_BLOB_INFO` - Set this to `1` if you want `pull-blob` to prepend each blob with its digest and size (printed in plain text, separated by a space and followed by a newline).
 - `DXF_CHUNK_SIZE` - Number of bytes `pull-blob` should download at a time. Defaults to 8192.
+- `DXF_SKIPTLSVERIFY` - Skip TLS certificate verification
 
 You can use the following options with `dxf`. Supply the name of the repository
 you wish to work with in each case as the second argument.

--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -123,7 +123,7 @@ class DXFBase(object):
     returned by :meth:`DXF.pull_blob` then the underlying connection won't be
     closed until Python garbage collects the iterator.
     """
-    def __init__(self, host, auth=None, insecure=False, auth_host=None):
+    def __init__(self, host, auth=None, insecure=False, auth_host=None, tlsverify=True):
         """
         :param host: Host name of registry. Can contain port numbers. e.g. ``registry-1.docker.io``, ``localhost:5000``.
         :type host: str
@@ -136,6 +136,9 @@ class DXFBase(object):
 
         :param auth_host: Host to use for token authentication. If set, overrides host returned by then registry.
         :type auth_host: str
+
+        :param tlsverify: When set to False, do not verify TLS certificate
+        :type tlsverify: bool
         """
         self._base_url = ('http' if insecure else 'https') + '://' + host + '/v2/'
         self._auth = auth
@@ -145,6 +148,14 @@ class DXFBase(object):
         self._headers = {}
         self._repo = None
         self._sessions = [requests]
+        self._tlsverify = tlsverify
+        if not tlsverify:
+            try:
+                from requests.packages import urllib3
+            except ImportError:
+                import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 
     @property
     def token(self):
@@ -164,7 +175,7 @@ class DXFBase(object):
 
     def _base_request(self, method, path, **kwargs):
         def make_kwargs():
-            r = {'allow_redirects': True}
+            r = {'allow_redirects': True, 'verify': self._tlsverify}
             r.update(kwargs)
             if 'headers' not in r:
                 r['headers'] = {}
@@ -211,7 +222,7 @@ class DXFBase(object):
         if self._insecure:
             raise exceptions.DXFAuthInsecureError()
         if response is None:
-            response = self._sessions[0].get(self._base_url)
+            response = self._sessions[0].get(self._base_url, verify=self._tlsverify)
         # pylint: disable=no-member
         if response.status_code != requests.codes.unauthorized:
             raise exceptions.DXFUnexpectedStatusCodeError(response.status_code,
@@ -244,7 +255,7 @@ class DXFBase(object):
             if self._auth_host:
                 url_parts[1] = self._auth_host
             auth_url = urlparse.urlunparse(url_parts)
-            r = self._sessions[0].get(auth_url, headers=headers)
+            r = self._sessions[0].get(auth_url, headers=headers, verify=self._tlsverify)
             _raise_for_status(r)
             self.token = r.json()['token']
             return self._token
@@ -277,7 +288,7 @@ class DXF(DXFBase):
     Class for operating on a Docker v2 repositories.
     """
     # pylint: disable=too-many-arguments
-    def __init__(self, host, repo, auth=None, insecure=False, auth_host=None):
+    def __init__(self, host, repo, auth=None, insecure=False, auth_host=None, tlsverify=True):
         """
         :param host: Host name of registry. Can contain port numbers. e.g. ``registry-1.docker.io``, ``localhost:5000``.
         :type host: str
@@ -293,8 +304,11 @@ class DXF(DXFBase):
 
         :param auth_host: Host to use for token authentication. If set, overrides host returned by then registry.
         :type auth_host: str
+
+        :param tlsverify: When set to False do not verify TLS certificate
+        :type tlsverify: bool
         """
-        super(DXF, self).__init__(host, auth, insecure, auth_host)
+        super(DXF, self).__init__(host, auth, insecure, auth_host, tlsverify)
         self._repo = repo
 
     def _request(self, method, path, **kwargs):

--- a/dxf/main.py
+++ b/dxf/main.py
@@ -49,6 +49,12 @@ def doit(args, environ):
     else:
         progress = None
 
+    dxf_skiptlsverify = environ.get('DXF_SKIPTLSVERIFY')
+    if dxf_skiptlsverify == '1':
+        dxf_tlsverify = False
+    else:
+        dxf_tlsverify = True
+
     def auth(dxf_obj, response):
         # pylint: disable=redefined-outer-name
         username = environ.get('DXF_USERNAME')
@@ -64,12 +70,14 @@ def doit(args, environ):
                           args.repo,
                           auth,
                           environ.get('DXF_INSECURE') == '1',
-                          environ.get('DXF_AUTH_HOST'))
+                          environ.get('DXF_AUTH_HOST'),
+                          tlsverify=dxf_tlsverify)
     else:
         dxf_obj = dxf.DXFBase(environ['DXF_HOST'],
                               auth,
                               environ.get('DXF_INSECURE') == '1',
-                              environ.get('DXF_AUTH_HOST'))
+                              environ.get('DXF_AUTH_HOST'),
+                              tlsverify=dxf_tlsverify)
 
     def _doit():
         # pylint: disable=too-many-branches


### PR DESCRIPTION
This PR adds an option to disable TLS certificate verification, in cases where REQUESTS_CA_BUNDLE is not enough (e.g. a development docker container that creates a self-signed cert on startup)