### PR TITLE
Document custom CA Certificate Bundle file

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -172,8 +172,8 @@ class DXFBase(object):
         :param auth_host: Host to use for token authentication. If set, overrides host returned by then registry.
         :type auth_host: str
 
-        :param tlsverify: When set to False, do not verify TLS certificate.
-        :type tlsverify: bool
+        :param tlsverify: When set to False, do not verify TLS certificate. When pointed to a `<ca bundle>.crt` file use this for TLS verification.
+        :type tlsverify: bool or str
         """
         self._base_url = ('http' if insecure else 'https') + '://' + host + '/v2/'
         self._host = host
@@ -360,8 +360,8 @@ class DXF(DXFBase):
         :param auth_host: Host to use for token authentication. If set, overrides host returned by then registry.
         :type auth_host: str
 
-        :param tlsverify: When set to False do not verify TLS certificate
-        :type tlsverify: bool
+        :param tlsverify: When set to False, do not verify TLS certificate. When pointed to a `<ca bundle>.crt` file use this for TLS verification.
+        :type tlsverify: bool or str
         """
         super(DXF, self).__init__(host, auth, insecure, auth_host, tlsverify)
         self._repo = repo

--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -172,7 +172,7 @@ class DXFBase(object):
         :param auth_host: Host to use for token authentication. If set, overrides host returned by then registry.
         :type auth_host: str
 
-        :param tlsverify: When set to False, do not verify TLS certificate. When pointed to a `<ca bundle>.crt` file use this for TLS verification.
+        :param tlsverify: When set to False, do not verify TLS certificate. When pointed to a `<ca bundle>.crt` file use this for TLS verification. See `requests.verify <http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification>` for more details.
         :type tlsverify: bool or str
         """
         self._base_url = ('http' if insecure else 'https') + '://' + host + '/v2/'
@@ -360,7 +360,7 @@ class DXF(DXFBase):
         :param auth_host: Host to use for token authentication. If set, overrides host returned by then registry.
         :type auth_host: str
 
-        :param tlsverify: When set to False, do not verify TLS certificate. When pointed to a `<ca bundle>.crt` file use this for TLS verification.
+        :param tlsverify: When set to False, do not verify TLS certificate. When pointed to a `<ca bundle>.crt` file use this for TLS verification. See `requests.verify <http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification>` for more details.
         :type tlsverify: bool or str
         """
         super(DXF, self).__init__(host, auth, insecure, auth_host, tlsverify)


### PR DESCRIPTION
Requests allows you to specify a certificate bundle, see their [documentation](http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification) for more details.

Tested with `dxf._tlsverify="/etc/ssl/certs/ca-certificates.crt"`

Not sure if it work though, but `if not tlsverify` should be only true if it's set to `False`. 
https://github.com/davedoesdev/dxf/pull/13/files#diff-4cc3d991830ef2e80eb839c4c0e6a692R151