### PR TITLE
Fix UnicodeDecodeError error when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
+import io
 import os
 from setuptools import setup
 
 def read(name):
-    return open(os.path.join(os.path.dirname(__file__), name)).read()
+    file_path = os.path.join(os.path.dirname(__file__), name)
+    return io.open(file_path, encoding='utf8').read()
 
 setup(
     name='python-dxf',


### PR DESCRIPTION
I am using Windows 10 Enterprise edition (Korean), and I usually work in Git Bash.

When attempting to install python-dxf, I get the following error:

```
(venv) C:\Users\Phil\Documents\dockerviz-registry>pip install python-dxf
Collecting python-dxf
  Using cached https://files.pythonhosted.org/packages/d1/cb/298cd299591616cd0fa544f94c59e241325a49d9dd2632911834d73f2723/python-dxf-7.5.0.tar.gz
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\Phil\AppData\Local\Temp\pip-install-vre_fdlo\python-dxf\setup.py", line 11, in <module>
        long_description=read('README.rst'),
      File "C:\Users\Phil\AppData\Local\Temp\pip-install-vre_fdlo\python-dxf\setup.py", line 5, in read
        return open(os.path.join(os.path.dirname(__file__), name)).read()
    UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in position 538: illegal multibyte sequence
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in C:\Users\Phil\AppData\Local\Temp\pip-install-vre_fdlo\python-dxf\
```

This can be solved by specifying `encoding='utf8'` for `open()`. To make it work with Python 2, I used `io.open()` instead of `open()`.