### PR TITLE
Add support for manipulating manifest lists

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -29,6 +29,7 @@ import www_authenticate
 from dxf import exceptions
 
 _schema2_mimetype = 'application/vnd.docker.distribution.manifest.v2+json'
+_schema2_list_mimetype = 'application/vnd.docker.distribution.manifest.list.v2+json'
 
 if sys.version_info < (3, 0):
     _binary_type = str
@@ -560,10 +561,11 @@ class DXF(DXFBase):
         :param manifest_json: A V2 Schema 2 manifest JSON string
         :type digests: list
         """
+        media_type = json.loads(manifest_json)['mediaType']
         self._request('put',
                       'manifests/' + alias,
                       data=manifest_json,
-                      headers={'Content-Type': _schema2_mimetype})
+                      headers={'Content-Type': media_type})
 
     def set_alias(self, alias, *digests):
         # pylint: disable=too-many-locals
@@ -606,8 +608,10 @@ class DXF(DXFBase):
         """
         r = self._request('get',
                           'manifests/' + alias,
-                          headers={'Accept': _schema2_mimetype + ', ' +
-                                             _schema1_mimetype})
+                          headers={'Accept': ', '.join((
+                                    _schema2_mimetype,
+                                    _schema1_mimetype,
+                                    _schema2_list_mimetype))})
         return r.content.decode('utf-8'), r
 
     def get_manifest(self, alias):


### PR DESCRIPTION
I made these changes because I wanted to be able retag manifest-list type manifests. With my changes I can retag a manifest-list:
```
manifest = dxf.get_manifest("oldtag")
dxf.set_manifest("newtag", manifest)
```

Manifest lists are a manifest with the content-type `application/vnd.docker.distribution.manifest.list.v2+json` which contains a list of manifests.
Example:
```
{
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "schemaVersion": 2,
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "digest": "sha256:933ebbba039321819e238f6a1601a765aa32efbd7d274c3eee65749bb6376e78",
         "size": 8864,
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "digest": "sha256:b13b617c9fb26b2fea3acf3270cbf312abdeca2996201122bf1589e111f26f5c",
         "size": 8866,
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```
I think the most common use case is to have a single docker name:tag with multiple platforms/architectures supported.

This set of changes likely breaks `set_alias` since my version reads the content-type from the json and doesn't hard-code it.

I'm happy to take any suggestions and/or feedback and incorporate them into my changes. I'd much rather upstream these changes than maintain my own fork.