### PR TITLE
support for get_alias with manifest list type aliases

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -665,8 +665,15 @@ class DXF(DXFBase):
             split_digest(dgst)
             return dgst
 
+        if parsed_manifest['mediaType'] == _schema2_mimetype:
+            blobs_key = 'layers'
+        elif parsed_manifest['mediaType'] == _schema2_list_mimetype:
+            blobs_key = 'manifests'
+        else:
+            raise exceptions.DXFUnsupportedSchemaType(parsed_manifest['mediaType'])
+
         r = []
-        for layer in parsed_manifest['layers']:
+        for layer in parsed_manifest[blobs_key]:
             dgst = layer['digest']
             split_digest(dgst)
             r.append((dgst, layer['size']) if sizes else dgst)

--- a/dxf/exceptions.py
+++ b/dxf/exceptions.py
@@ -99,3 +99,10 @@ class DXFMountFailed(DXFError):
     """
     def __str__(self):
         return 'Cross repository blob mount failed'
+
+class DXFUnsupportedSchemaType(DXFError):
+    """
+    Schema type (mediaType) is not recognized/supported
+    """
+    def __str__(self):
+        return 'The mediaType "%s" is not supported' % self.args[0]


### PR DESCRIPTION
`_get_alias` was broken for the case of manifest lists. When it tried to get the blob digests pointed to by the manifest, it attempts to access the key `layers` which doesn't exist in a manifest list. In a manifest list, the key `manifests` exists and has relatively the same info, except the digest are for manifests, not layers.

Example manifest list:
```
{
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "schemaVersion": 2,
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "digest": "sha256:fdeb461901e10fa75bc54162691ada2ec9e43cbb909e91424cc6b7bbc0e31766",
         "size": 523,
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "digest": "sha256:7119ae66182c7d6cc2e2ac7f34abb20a8a6fc4d38ca3b611eb65ae35eed22606",
         "size": 523,
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
}
```

I also put in the unsupported schema exception so that a more explicit error would be raised if a new or unexpected schema type is hit. It isn't strictly necessary.