### PR TITLE
Move types from docstrings to annotations

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -2,6 +2,8 @@
 Module for accessing a Docker v2 Registry
 """
 
+from typing import Optional, Union, List, Callable, Iterable, Type, Iterator, TypeVar, Tuple, TYPE_CHECKING, Dict, Protocol
+from types import ModuleType
 import base64
 import hashlib
 import json
@@ -38,31 +40,30 @@ else:
     # pylint: disable=redefined-builtin
     long = int
 
+T = TypeVar('T', bound='DXFBase')
+TD = TypeVar('TD', bound='DXF')
+
 def _to_bytes_2and3(s):
     return s if isinstance(s, _binary_type) else s.encode('utf-8')
 
-def hash_bytes(buf):
+def hash_bytes(buf: _binary_type) -> str:
     """
     Hash bytes using the same method the registry uses (currently SHA-256).
 
     :param buf: Bytes to hash
-    :type buf: binary str
 
-    :rtype: str
     :returns: Hex-encoded hash of file's content (prefixed by ``sha256:``)
     """
     sha256 = hashlib.sha256()
     sha256.update(buf)
     return 'sha256:' + sha256.hexdigest()
 
-def hash_file(filename):
+def hash_file(filename: str) -> str:
     """
     Hash a file using the same method the registry uses (currently SHA-256).
 
     :param filename: Name of file to hash
-    :type filename: str
 
-    :rtype: str
     :returns: Hex-encoded hash of file's content (prefixed by ``sha256:``)
     """
     sha256 = hashlib.sha256()
@@ -129,7 +130,7 @@ class PaginatingResponse(object):
         self._path = path
         self._header = header
         self._kwargs = kwargs
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         while self._path:
             response = self._meth('get', self._path, **self._kwargs)
             self._kwargs = {}
@@ -159,27 +160,21 @@ class DXFBase(object):
     returned by :meth:`DXF.pull_blob` then the underlying connection won't be
     closed until Python garbage collects the iterator.
     """
-    def __init__(self, host,
-                 auth=None, insecure=False, auth_host=None, tlsverify=True, timeout=None):
+    def __init__(self, host: str,
+            auth: Optional[Callable[['DXFBase', requests.Response], None]]=None, insecure: bool=False, auth_host: Optional[str]=None, tlsverify: Union[bool, str]=True, timeout: Optional[float]=None):
         # pylint: disable=too-many-arguments
         """
         :param host: Host name of registry. Can contain port numbers. e.g. ``registry-1.docker.io``, ``localhost:5000``.
-        :type host: str
 
         :param auth: Authentication function to be called whenever authentication to the registry is required. Receives the :class:`DXFBase` object and a HTTP response object. It should call :meth:`authenticate` with a username, password and ``response`` before it returns.
-        :type auth: function(dxf_obj, response)
 
         :param insecure: Use HTTP instead of HTTPS (which is the default) when connecting to the registry.
-        :type insecure: bool
 
         :param auth_host: Host to use for token authentication. If set, overrides host returned by then registry.
-        :type auth_host: str
 
         :param tlsverify: When set to False, do not verify TLS certificate. When pointed to a `<ca bundle>.crt` file use this for TLS verification. See `requests.verify <http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification>`_ for more details.
-        :type tlsverify: bool or str
 
         :param timeout: Optional timeout for requests. See `requests.timeout <https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts>`_ for more details.
-        :type timeout: float
         """
         self._base_url = ('http' if insecure else 'https') + '://' + host + '/v2/'
         self._host = host
@@ -187,9 +182,9 @@ class DXFBase(object):
         self._insecure = insecure
         self._auth_host = auth_host
         self._token = None
-        self._headers = {}
-        self._repo = None
-        self._sessions = [requests]
+        self._headers: Dict[str, str] = {}
+        self._repo: Optional[str] = None
+        self._sessions: List[requests.Session] = [requests]
         self._tlsverify = tlsverify
         self._timeout = timeout
 
@@ -233,34 +228,27 @@ class DXFBase(object):
         return r
 
     def authenticate(self,
-                     username=None, password=None,
-                     actions=None, response=None,
-                     authorization=None,
-                     user_agent='Docker-Client/19.03.2 (linux)'):
+            username: Optional[str]=None, password: Optional[str]=None,
+            actions: Optional[List[str]]=None, response: Optional[requests.Response]=None,
+            authorization: Optional[str]=None,
+            user_agent: str='Docker-Client/19.03.2 (linux)') -> Optional[str]:
         # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
         """
         Authenticate to the registry using a username and password,
         an authorization header or otherwise as the anonymous user.
 
         :param username: User name to authenticate as.
-        :type username: str
 
         :param password: User's password.
-        :type password: str
 
         :param actions: If you know which types of operation you need to make on the registry, specify them here. Valid actions are ``pull``, ``push`` and ``*``.
-        :type actions: list
 
         :param response: When the ``auth`` function you passed to :class:`DXFBase`'s constructor is called, it is passed a HTTP response object. Pass it back to :meth:`authenticate` to have it automatically detect which actions are required.
-        :type response: requests.Response
 
         :param authorization: ``Authorization`` header value.
-        :type authorization: str
 
         :param user_agent: ``User-Agent`` header value.
-        :type user_agent: str
 
-        :rtype: str
         :returns: Authentication token, if the registry supports bearer tokens. Otherwise ``None``, and HTTP Basic auth is used (if the registry requires authentication).
         """
         if response is None:
@@ -330,17 +318,14 @@ class DXFBase(object):
         self._headers = headers
         return None
 
-    def list_repos(self, batch_size=None, iterate=False):
+    def list_repos(self, batch_size: Optional[int]=None, iterate: bool=False) -> Union[List[str], Iterable[str]]:
         """
         List all repositories in the registry.
 
         :param batch_size: Number of repository names to ask the server for at a time.
-        :type batch_size: int
 
         :param iterate: Whether to return iterator over the names or a list of all the names.
-        :type iterate: bool
 
-        :rtype: list or iterator of strings
         :returns: Repository names.
         """
         it = PaginatingResponse(self, '_base_request',
@@ -348,7 +333,7 @@ class DXFBase(object):
                                 params={'n': batch_size})
         return it if iterate else list(it)
 
-    def __enter__(self):
+    def __enter__(self: T) -> T:
         assert self._sessions
         session = requests.Session()
         session.__enter__()
@@ -366,29 +351,22 @@ class DXF(DXFBase):
     """
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, host, repo, auth=None, insecure=False, auth_host=None, tlsverify=True, timeout=None):
+    def __init__(self: TD, host: str, repo: str, auth: Callable[['DXFBase', requests.Response], None]=None, insecure: bool=False, auth_host: Optional[str]=None, tlsverify: Union[bool, str]=True, timeout: Optional[float]=None):
         # pylint: disable=too-many-arguments
         """
         :param host: Host name of registry. Can contain port numbers. e.g. ``registry-1.docker.io``, ``localhost:5000``.
-        :type host: str
 
         :param repo: Name of the repository to access on the registry. Typically this is of the form ``username/reponame`` but for your own registries you don't actually have to stick to that.
-        :type repo: str
 
         :param auth: Authentication function to be called whenever authentication to the registry is required. Receives the :class:`DXF` object and a HTTP response object. It should call :meth:`DXFBase.authenticate` with a username, password and ``response`` before it returns.
-        :type auth: function(dxf_obj, response)
 
         :param insecure: Use HTTP instead of HTTPS (which is the default) when connecting to the registry.
-        :type insecure: bool
 
         :param auth_host: Host to use for token authentication. If set, overrides host returned by then registry.
-        :type auth_host: str
 
         :param tlsverify: When set to False, do not verify TLS certificate. When pointed to a `<ca bundle>.crt` file use this for TLS verification. See `requests.verify <http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification>`_ for more details.
-        :type tlsverify: bool or str
 
         :param timeout: Optional timeout for requests. See `requests.timeout <https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts>`_ for more details.
-        :type timeout: float
         """
         super(DXF, self).__init__(host, auth, insecure, auth_host, tlsverify, timeout)
         self._repo = repo
@@ -409,10 +387,10 @@ class DXF(DXFBase):
             **kwargs)
 
     def push_blob(self,
-                  filename=None,
-                  progress=None,
-                  data=None, digest=None,
-                  check_exists=True):
+            filename: Optional[str]=None,
+            progress: Optional[Callable[[str, _binary_type, int], None]]=None,
+            data: Optional[Iterable[_binary_type]]=None, digest: Optional[str]=None,
+            check_exists: bool=True) -> str:
         # pylint: disable=too-many-arguments
         """
         Upload a file to the registry and return its (SHA-256) hash.
@@ -421,25 +399,21 @@ class DXF(DXFBase):
         can be retrieved later by passing the hash to :meth:`pull_blob`.
 
         :param filename: File to upload.
-        :type filename: str
 
         :param data: Data to upload if ``filename`` isn't given. The data is uploaded in chunks and you must also pass ``digest``.
-        :type data: Generator or iterator
 
         :param digest: Hash of the data to be uploaded in ``data``, if specified.
-        :type digest: str (hex-encoded SHA-256, prefixed by ``sha256:``)
 
         :param progress: Optional function to call as the upload progresses. The function will be called with the hash of the file's content (or ``digest``), the blob just read from the file (or chunk from ``data``) and if ``filename`` is specified the total size of the file.
-        :type progress: function(dgst, chunk, size)
 
         :param check_exists: Whether to check if a blob with the same hash already exists in the registry. If so, it won't be uploaded again.
-        :type check_exists: bool
 
-        :rtype: str
         :returns: Hash of file's content.
         """
         if filename is None:
             dgst = digest
+            if dgst is None:
+                raise TypeError("digest must be provided if filename is None")
         else:
             dgst = hash_file(filename)
         if check_exists:
@@ -468,20 +442,16 @@ class DXF(DXFBase):
         return dgst
 
     # pylint: disable=no-self-use
-    def pull_blob(self, digest, size=False, chunk_size=None):
+    def pull_blob(self, digest: str, size: bool=False, chunk_size: Optional[int]=None) -> Union[Iterable[_binary_type], Tuple[Iterable[_binary_type], long]]:
         """
         Download a blob from the registry given the hash of its content.
 
         :param digest: Hash of the blob's content (prefixed by ``sha256:``).
-        :type digest: str
 
         :param size: Whether to return the size of the blob too.
-        :type size: bool
 
         :param chunk_size: Number of bytes to download at a time. Defaults to 8192.
-        :type chunk_size: int
 
-        :rtype: iterator
         :returns: If ``size`` is falsey, a byte string iterator over the blob's content. If ``size`` is truthy, a tuple containing the iterator and the blob's size.
         """
         if chunk_size is None:
@@ -499,30 +469,25 @@ class DXF(DXFBase):
                     raise exceptions.DXFDigestMismatchError(dgst, digest)
         return (Chunks(), long(r.headers['content-length'])) if size else Chunks()
 
-    def blob_size(self, digest):
+    def blob_size(self, digest: str) -> long:
         """
         Return the size of a blob in the registry given the hash of its content.
 
         :param digest: Hash of the blob's content (prefixed by ``sha256:``).
-        :type digest: str
 
-        :rtype: long
         :returns: Size of the blob in bytes.
         """
         r = self._request('head', 'blobs/' + digest)
         return long(r.headers['content-length'])
 
-    def mount_blob(self, repo, digest):
+    def mount_blob(self, repo: str, digest: str) -> str:
         """
         Mount a blob from another repository in the registry.
 
         :param repo: Repository containing the existing blob.
-        :type repo: str
 
         :param digest: Hash of the existing blob's content (prefixed by ``sha256:``).
-        :type digest: str
 
-        :rtype: str
         :returns: Hash of blob's content.
         """
         r = self._request('post', 'blobs/uploads/?' + urlencode({
@@ -534,12 +499,11 @@ class DXF(DXFBase):
             raise exceptions.DXFMountFailed()
         return r.headers.get('Docker-Content-Digest')
 
-    def del_blob(self, digest):
+    def del_blob(self, digest: str):
         """
         Delete a blob from the registry given the hash of its content.
 
         :param digest: Hash of the blob's content (prefixed by ``sha256:``).
-        :type digest: str
         """
         self._request('delete', 'blobs/' + digest)
 
@@ -564,15 +528,13 @@ class DXF(DXFBase):
             'layers': layers
         }, sort_keys=True)
 
-    def set_manifest(self, alias, manifest_json):
+    def set_manifest(self, alias: str, manifest_json: str):
         """
         Give a name (alias) to a manifest.
 
         :param alias: Alias name
-        :type alias: str
 
         :param manifest_json: A V2 Schema 2 manifest JSON string
-        :type digests: list
         """
         media_type = json.loads(manifest_json)['mediaType']
         self._request('put',
@@ -580,19 +542,16 @@ class DXF(DXFBase):
                       data=manifest_json,
                       headers={'Content-Type': media_type})
 
-    def set_alias(self, alias, *digests):
+    def set_alias(self, alias: str, *digests: str) -> str:
         # pylint: disable=too-many-locals
         """
         Give a name (alias) to a set of blobs. Each blob is specified by
         the hash of its content.
 
         :param alias: Alias name
-        :type alias: str
 
         :param digests: List of blob hashes (prefixed by ``sha256:``).
-        :type digests: list of strings
 
-        :rtype: str
         :returns: The registry manifest used to define the alias. You almost definitely won't need this.
         """
         try:
@@ -608,15 +567,13 @@ class DXF(DXFBase):
             self._request('put', 'manifests/' + alias, data=signed_json)
             return signed_json
 
-    def get_manifest_and_response(self, alias):
+    def get_manifest_and_response(self, alias: str) -> Tuple[str, requests.Response]:
         """
         Request the manifest for an alias and return the manifest and the
         response.
 
         :param alias: Alias name.
-        :type alias: str
 
-        :rtype: tuple
         :returns: Tuple containing the manifest as a string (JSON) and the `requests.Response <http://docs.python-requests.org/en/master/api/#requests.Response>`_
         """
         r = self._request('get',
@@ -627,14 +584,12 @@ class DXF(DXFBase):
                               _schema2_list_mimetype))})
         return r.content.decode('utf-8'), r
 
-    def get_manifest(self, alias):
+    def get_manifest(self, alias: str) -> str:
         """
         Get the manifest for an alias
 
         :param alias: Alias name.
-        :type alias: str
 
-        :rtype: str
         :returns: The manifest as string (JSON)
         """
         manifest, _ = self.get_manifest_and_response(alias)
@@ -693,40 +648,34 @@ class DXF(DXFBase):
         return r
 
     def get_alias(self,
-                  alias=None,
-                  manifest=None,
-                  verify=True,
-                  sizes=False,
-                  dcd=None):
+            alias: Optional[str]=None,
+            manifest: Optional[str]=None,
+            verify: bool=True,
+            sizes: bool=False,
+            dcd: Optional[str]=None) -> Union[List[str], List[Tuple[str, long]]]:
         # pylint: disable=too-many-arguments
         """
         Get the blob hashes assigned to an alias.
 
         :param alias: Alias name. You almost definitely will only need to pass this argument.
-        :type alias: str
 
         :param manifest: If you previously obtained a manifest, specify it here instead of ``alias``. You almost definitely won't need to do this.
-        :type manifest: str
 
         :param verify: (v1 schema only) Whether to verify the integrity of the alias definition in the registry itself. You almost definitely won't need to change this from the default (``True``).
-        :type verify: bool
 
         :param sizes: Whether to return sizes of the blobs along with their hashes
-        :type sizes: bool
 
         :param dcd: (if ``manifest`` is specified) The Docker-Content-Digest header returned when getting the manifest. If present, this is checked against the manifest.
-        :type dcd: str
 
-        :rtype: list
         :returns: If ``sizes`` is falsey, a list of blob hashes (strings) which are assigned to the alias. If ``sizes`` is truthy, a list of (hash,size) tuples for each blob.
         """
         return self._get_alias(alias, manifest, verify, sizes, dcd, False)
 
     def get_digest(self,
-                   alias=None,
-                   manifest=None,
-                   verify=True,
-                   dcd=None):
+            alias: Optional[str]=None,
+            manifest: Optional[str]=None,
+            verify: bool=True,
+            dcd: Optional[str]=None) -> str:
         """
         (v2 schema only) Get the hash of an alias's configuration blob.
 
@@ -737,30 +686,23 @@ class DXF(DXFBase):
         ``docker inspect alias --format='{{.Id}}'``.
 
         :param alias: Alias name. You almost definitely will only need to pass this argument.
-        :type alias: str
 
         :param manifest: If you previously obtained a manifest, specify it here instead of ``alias``. You almost definitely won't need to do this.
-        :type manifest: str
 
         :param verify: (v1 schema only) Whether to verify the integrity of the alias definition in the registry itself. You almost definitely won't need to change this from the default (``True``).
-        :type verify: bool
 
         :param dcd: (if ``manifest`` is specified) The Docker-Content-Digest header returned when getting the manifest. If present, this is checked against the manifest.
-        :type dcd: str
 
-        :rtype: str
         :returns: Hash of the alias's configuration blob.
         """
         return self._get_alias(alias, manifest, verify, False, dcd, True)
 
-    def _get_dcd(self, alias):
+    def _get_dcd(self, alias: str) -> str:
         """
         Get the Docker-Content-Digest header for an alias.
 
         :param alias: Alias name.
-        :type alias: str
 
-        :rtype: str
         :returns: DCD header for the alias.
         """
         # https://docs.docker.com/registry/spec/api/#deleting-an-image
@@ -774,7 +716,7 @@ class DXF(DXFBase):
             headers={'Accept': _schema2_mimetype},
         ).headers.get('Docker-Content-Digest')
 
-    def del_alias(self, alias):
+    def del_alias(self, alias: str) -> List[str]:
         """
         Delete an alias from the registry. The blobs it points to won't be deleted. Use :meth:`del_blob` for that.
 
@@ -783,27 +725,24 @@ class DXF(DXFBase):
            https://docs.docker.com/registry/garbage-collection/
 
         :param alias: Alias name.
-        :type alias: str
 
-        :rtype: list
         :returns: A list of blob hashes (strings) which were assigned to the alias.
         """
         dcd = self._get_dcd(alias)
+        if TYPE_CHECKING:
+            assert isinstance(dcd, list)
         dgsts = self.get_alias(alias)
         self._request('delete', 'manifests/{}'.format(dcd))
         return dgsts
 
-    def list_aliases(self, batch_size=None, iterate=False):
+    def list_aliases(self, batch_size: Optional[int]=None, iterate: bool=False) -> Union[Iterable[str], List[str]]:
         """
         List all aliases defined in the repository.
 
         :param batch_size: Number of alias names to ask the server for at a time.
-        :type batch_size: int
 
         :param iterate: Whether to return iterator over the names or a list of all the names.
-        :type iterate: bool
 
-        :rtype: list or iterator of strings
         :returns: Alias names.
         """
         it = PaginatingResponse(self, '_request',
@@ -811,30 +750,26 @@ class DXF(DXFBase):
                                 params={'n': batch_size})
         return it if iterate else list(it)
 
-    def api_version_check(self):
+    def api_version_check(self) -> Tuple[str, requests.Response]:
         """
         Performs API version check
 
-        :rtype: tuple
         :returns: verson check response as a string (JSON) and requests.Response
         """
         r = self._base_request('get', '')
         return r.content.decode('utf-8'), r
 
     @classmethod
-    def from_base(cls, base, repo):
+    def from_base(cls: Type[TD], base: 'DXFBase', repo: str) -> TD:
         """
         Create a :class:`DXF` object which uses the same host, settings and
         session as an existing :class:`DXFBase` object.
 
         :param base: Existing :class:`DXFBase` object.
-        :type base: :class:`DXFBase`
 
         :param repo: Name of the repository to access on the registry. Typically this is of the form ``username/reponame`` but for your own registries you don't actually have to stick to that.
-        :type repo: str
 
         :returns: :class:`DXF` object which shares configuration and session with ``base`` but which can also be used to operate on the ``repo`` repository.
-        :rtype: :class:`DXF`
         """
         # pylint: disable=protected-access
         r = cls(base._host, repo, base._auth, base._insecure, base._auth_host, base._tlsverify, base._timeout)

--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -3,7 +3,6 @@ Module for accessing a Docker v2 Registry
 """
 
 from typing import Optional, Union, List, Callable, Iterable, Type, Iterator, TypeVar, Tuple, TYPE_CHECKING, Dict, Protocol
-from types import ModuleType
 import base64
 import hashlib
 import json

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     url='https://github.com/davedoesdev/dxf',
     license='MIT',
     packages=['dxf'],
+    package_data={"dxf": ["py.typed"]},
     entry_points={'console_scripts': ['dxf=dxf.main:main']},
     install_requires=['www-authenticate>=0.9.2',
                       'requests>=2.18.4',


### PR DESCRIPTION
This PR enables type checking against dxf with e.g. mypy when used as a library. This entailed moving the type definitions from the docstrings to annotations (this should preserve the type information in the docs) and making a few small fixes - there were some typos, and some types needed to be converted to generics. dxf itself doesn't typecheck yet - there are outstanding issues with the type annotations of its dependencies, and the type-punning between the requests module and Session objects is not something I particularly know how to express... In any case, this allows my application importing dxf to typecheck properly in mypy.