### PR TITLE
Add OCIv1 media type support when fetching manifest

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -31,6 +31,12 @@ from dxf import exceptions
 _schema2_mimetype = 'application/vnd.docker.distribution.manifest.v2+json'
 _schema2_list_mimetype = 'application/vnd.docker.distribution.manifest.list.v2+json'
 
+# OCIv1 equivalent of a docker registry v2 manifests
+_ociv1_manifest_mimetype = 'application/vnd.oci.image.manifest.v1+json'
+# OCIv1 equivalent of a docker registry v2 "manifests list"
+_ociv1_index_mimetype = 'application/vnd.oci.image.index.v1+json'
+
+
 if sys.version_info < (3, 0):
     _binary_type = str
 else:
@@ -624,7 +630,11 @@ class DXF(DXFBase):
                           headers={'Accept': ', '.join((
                               _schema2_mimetype,
                               _schema1_mimetype,
-                              _schema2_list_mimetype))})
+                              _schema2_list_mimetype,
+                              _ociv1_manifest_mimetype,
+                              _ociv1_index_mimetype,
+                              ))})
+
         return r.content.decode('utf-8'), r
 
     def get_manifest(self, alias):
@@ -678,9 +688,9 @@ class DXF(DXFBase):
             split_digest(dgst)
             return dgst
 
-        if parsed_manifest['mediaType'] == _schema2_mimetype:
+        if parsed_manifest['mediaType'] == _schema2_mimetype or parsed_manifest['mediaType'] == _ociv1_manifest_mimetype:
             blobs_key = 'layers'
-        elif parsed_manifest['mediaType'] == _schema2_list_mimetype:
+        elif parsed_manifest['mediaType'] == _schema2_list_mimetype or parsed_manifest["mediaType"] == _ociv1_index_mimetype:
             blobs_key = 'manifests'
         else:
             raise exceptions.DXFUnsupportedSchemaType(parsed_manifest['mediaType'])


### PR DESCRIPTION
# Disclaimer

I'm not very fluent with either this library or Docker registries in general. I don't know if I covered everything properly, or just my own use case :upside_down_face:

# A bit of context

Docker registries support several formats, among which
- docker v1 images (old and deprecated)
- docker v2 images (widely used for the last years as far as I understood)
- OCI v1, which has existed for a while but was not widely used until recently

For what I understood, the introduction of  the new `buildx` driver for Docker build (https://github.com/docker/buildx) has also caused the Docker client to upload images using the OCI v1 spec. I also suspect that the Docer Hub has started converting images in the background, as downloads that previously worked on some of our images using the DXF lib have broken a few days ago.

For instance, the Ubuntu images on the Docker Hub now use the new media types.

For more details about OCIv1 spec:
- https://github.com/opencontainers/image-spec/blob/main/image-index.md
- https://github.com/opencontainers/image-spec/blob/main/manifest.md

# What I did

When fetching a manifest (or manifest list), the client used to set Accept headers to accept docker-v1 or docker-v2 manifests mime types
- application/vnd.docker.distribution.manifest.v1+json
- application/vnd.docker.distribution.manifest.v2+json
- application/vnd.docker.distribution.manifest.list.v2+json

This commit adds the following mime types:
- application/vnd.oci.image.manifest.v1+json (https://github.com/opencontainers/image-spec/blob/main/manifest.md)
- application/vnd.oci.image.index.v1+json (https://github.com/opencontainers/image-spec/blob/main/image-index.md)
corresponding to "OCI registry v1" types.

OCI manifests being a backwards-compatible superset of Docker manifests v2, the rest of the code should continue to work fine (of course ignoring any extension specific to OCI v1). However, as I said, I'm not familiar with this codebase and I use only a few library functions, so I may be missing things. Please don't hesitate to point me in the right directions if there are some other changes required.