### PR TITLE
Fix the _accept_header taint

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -215,8 +215,8 @@ class DXFBase(object):
         def make_kwargs():
             r = {'allow_redirects': True, 'verify': self._tlsverify, 'timeout': self._timeout}
             r.update(kwargs)
-            if 'headers' not in r:
-                r['headers'] = {}
+            r['headers'] = {}
+            r['headers'].update(kwargs.get('headers', {}))
             r['headers'].update(self._headers)
             return r
         url = urlparse.urljoin(self._base_url, path)


### PR DESCRIPTION
Base request will mutate the incoming headers dict, adding the 'authorization' all the way into `_accept_header` (as it's passed by reference). This will break the library globally if there's a need to auth to several different registries.