### PR TITLE
Bugfix: Fix list comprehension in make_manifest

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -519,11 +519,18 @@ class DXF(DXFBase):
         self._request('delete', 'blobs/' + digest)
 
     def make_manifest(self, *digests):
-        layers = [{
-            'mediaType': 'application/octet-stream',
-            'size': self.blob_size(dgst),
-            'digest': dgst
-        } for dgst_sublist in digests for dgst in dgst_sublist]
+        if isinstance(digests[0], list):
+            layers = [{
+                'mediaType': 'application/octet-stream',
+                'size': self.blob_size(dgst),
+                'digest': dgst
+            } for dgst_sublist in digests for dgst in dgst_sublist]
+        else:
+            layers = [{
+                'mediaType': 'application/octet-stream',
+                'size': self.blob_size(digests[0]),
+                'digest': digests[0]
+            }]
         return json.dumps({
             'schemaVersion': 2,
             #'mediaType': _ociv1_manifest_mimetype,

--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -523,7 +523,7 @@ class DXF(DXFBase):
             'mediaType': 'application/octet-stream',
             'size': self.blob_size(dgst),
             'digest': dgst
-        } for dgst in digests]
+        } for dgst_sublist in digests for dgst in dgst_sublist]
         return json.dumps({
             'schemaVersion': 2,
             #'mediaType': _ociv1_manifest_mimetype,


### PR DESCRIPTION
Hello, I founded the bug in the `make_manifest` function.

## Introduction
I would like to use `set_alias()` function to update alias for the image. I have 2 aliases for the same image: "old" and "new".  
To get aliases I used: `dxf.get_alias(old_alias)` function which return List of String. But I had an error:
```
Traceback (most recent call last):
....
  File "/a/b/c/.venv/lib/python3.11/site-packages/dxf/__init__.py", line 575, in set_alias
    manifest_json = self.make_manifest(*digests)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/a/b/c/.venv/lib/python3.11/site-packages/dxf/__init__.py", line 526, in make_manifest
    } for dgst in digest_list for digest_list in digests]
                  ^^^^^^^^^^^
NameError: name 'digest_list' is not defined
```

## Python list comprehension bug
We have `make_manifest`, which have parameter `digests`, that is an `*args` argument.
But in the list comprehension instead iterate over list, we iterate over matrix list :)

Example: 
```
>>> def foo(*args):
...     print(args)
...     print(*args)
...     print([x for x in args])
...
>>>
>>> foo([1,2,3])
([1, 2, 3],)
[1, 2, 3]
[[1, 2, 3]]
```

## How I fixed it?
I changed from list comprehension to nested list comprehension.


Thanks 



