### PR TITLE
re-export exceptions import

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -19,7 +19,7 @@ from urllib3.exceptions import InsecureRequestWarning
 from jwcrypto import jwk, jws # type: ignore
 import www_authenticate # type: ignore
 # pylint: disable=wildcard-import
-from dxf import exceptions
+from . import exceptions as exceptions
 
 _schema1_mimetype = 'application/vnd.docker.distribution.manifest.v1+json'
 


### PR DESCRIPTION
This makes pyright work correctly, and not complain that these names are "not exported". Apparently at some point, someone at microsoft decided that you have to either use __all__ or from .thing import Thing as Thing in order to indicate that an import is meant to be exported as well.