### PR TITLE
Fix token auth when `service` is missing

### DIFF
--- a/dxf/__init__.py
+++ b/dxf/__init__.py
@@ -302,7 +302,8 @@ class DXFBase(object):
                 scope = ''
             url_parts = list(urlparse.urlparse(info['realm']))
             query = urlparse.parse_qsl(url_parts[4])
-            query.append(('service', info['service']))
+            if 'service' in info:
+                query.append(('service', info['service']))
             query.extend(('scope', s) for s in scope.split())
             url_parts[4] = urlencode(query, True)
             url_parts[0] = 'https'


### PR DESCRIPTION
Make the `service` parameter optional, since some registries do not use it. The same logic [can be found in containerd](https://github.com/containerd/containerd/blob/61f91b963ef244daec1bda6700fe3f0b1aee50c6/core/remotes/docker/auth/fetch.go#L187).

Fixes #57